### PR TITLE
1.5.1 - Fix ipv6 errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,6 @@ version = "1.5.0"
 description = "Queries various providers for information about IP addresses."
 readme = "README.md"
 requires-python = ">=3.10"
-
 dependencies = [
     "keyring",
     "pyperclip>=1.8",

--- a/src/ip_info/_ask_yn.py
+++ b/src/ip_info/_ask_yn.py
@@ -1,0 +1,27 @@
+
+def _ask_yn(
+    question: str,
+    *,
+    true: str = "y"
+) -> bool:
+    """
+    Prompt the user with a yes/no question.
+
+    Args:
+        question: Text of the prompt.
+        true: Which response ("y" or "n") should be treated as True.
+              Defaults to "y".
+
+    Returns:
+        bool: True  if the user's choice matches `true`
+              False otherwise.
+    """
+    true = true.lower()
+    if true not in ("y", "n"):
+        raise ValueError("true must be 'y' or 'n'")
+
+    while True:
+        choice = input(f"{question} (y/n): ").strip().lower()
+        if choice in ("y", "n"):
+            return choice == true
+        print("Please enter 'y' or 'n'.")

--- a/src/ip_info/_display_ip_info.py
+++ b/src/ip_info/_display_ip_info.py
@@ -1,7 +1,7 @@
+import ipaddress
 import json
 import sqlite3
 import tabulate
-from typing import Iterable
 
 from ip_info.db._query_db import _fetch_ip_info
 from ip_info._format_timestamp import _format_timestamp
@@ -18,7 +18,7 @@ DISPLAY_COLUMNS = [
 
 def _display_ip_info(
     *,
-    ip_addresses: Iterable[str],
+    ip_addresses: list[ipaddress.IPv4Address | ipaddress.IPv6Address],
     output_format: str,
     db_conn: sqlite3.Connection,
 ) -> None:
@@ -36,7 +36,11 @@ def _display_ip_info(
 
     for ip_address in ip_addresses:
         print(f"Results for {ip_address}")
-        rows = _fetch_ip_info("all", ip_address, db_conn=db_conn)
+        rows = _fetch_ip_info(
+            api_names=["all"],
+            ip_address=ip_address, 
+            db_conn=db_conn
+        )
 
         if not rows:
             print(f"No data for {ip_address}.")

--- a/src/ip_info/_format_ownership.py
+++ b/src/ip_info/_format_ownership.py
@@ -1,5 +1,5 @@
 import re
-from typing import Dict, List
+from typing import Dict
 
 
 def _normalize_text(text: str) -> str:
@@ -21,7 +21,7 @@ def _normalize_text(text: str) -> str:
 def _format_ownership(row:Dict) -> str:
     """Return a canonical ‘ownership’ string from company / ISP / AS-name fields."""
 
-    raw_values: List[str] = [
+    raw_values: list[str] = [
         row.get("company", ""),
         row.get("isp", ""),
         row.get("as_name", ""),
@@ -31,7 +31,7 @@ def _format_ownership(row:Dict) -> str:
     if not values:
         return ""
 
-    uniques: List[str] = []
+    uniques: list[str] = []
     seen_normalised = set()
 
     for v in values:

--- a/src/ip_info/_parse_clipboard.py
+++ b/src/ip_info/_parse_clipboard.py
@@ -9,53 +9,17 @@ _IPV6_RE = r"\b(?:[A-F0-9]{1,4}:){2,7}[A-F0-9]{1,4}\b"
 _IP_RE = re.compile(f"{_IPV4_RE}|{_IPV6_RE}", flags=re.IGNORECASE)
 
 
-def _parse_clipboard(
-    *, 
-    verbose: bool = True, 
-    ask_user: bool = True
-) -> List[str]:
+def _parse_clipboard() -> List[str]:
     """
     Scrape the system clipboard for anything that *looks* like an IPv4/IPv6
     address.
-
-    If ask_user is True (default) we ask for confirmation before
-    touching the clipboard.  A negative response exits the program.
-
-    Parameters
-    ----------
-    verbose : bool
-        Print how many candidate IPs were found.
-    ask_user : bool
-        Whether to prompt the caller before reading the clipboard.
-
-    Returns
-    -------
-    list[str]
-        A (possibly empty) list of IP-like strings.
     """
-    if ask_user:
-        try:
-            reply = input(
-                "No IP addresses were supplied. "
-                "Parse the clipboard for IP addresses? [y/N]: "
-            ).strip().lower()
-        except (EOFError, KeyboardInterrupt):
-            reply = "n"
-
-        if reply not in {"y", "yes"}:
-            sys.exit("Exiting - clipboard parsing declined.")
 
     try:
       raw_text = pyperclip.paste()
     except pyperclip.PyperclipException as exception:
         sys.exit(f"clipboard error: {exception}")
 
-    ip_addresses = _IP_RE.findall(raw_text)
+    user_input = _IP_RE.findall(raw_text)
 
-    if not ip_addresses:
-        sys.exit("No IP addresses supplied and none detected in clipboard.")
-
-    if verbose:
-        print(f"Found {len(ip_addresses)} potential IPs in clipboard")
-
-    return ip_addresses
+    return user_input

--- a/src/ip_info/_validate_ip_addresses.py
+++ b/src/ip_info/_validate_ip_addresses.py
@@ -1,11 +1,10 @@
 import ipaddress
-from typing import List
 
 def _validate_ip_addresses(
     *,
     user_input: list[str], 
     verbose: bool = True
-) -> list[str]:
+) -> list[ipaddress.IPv4Address | ipaddress.IPv6Address]:
     """
     Validate and filter a list of IPs, keeping only valid public addresses.
 
@@ -16,19 +15,23 @@ def _validate_ip_addresses(
     Returns:
         A new list containing only those inputs that parsed as IPv4/IPv6 and are global (public) addresses.
     """
-    valid_ips: List[str] = []
+    valid_ips: list[ipaddress.IPv4Address | ipaddress.IPv6Address] = []
     seen: set[ipaddress.IPv4Address | ipaddress.IPv6Address] = set()
 
     for string in user_input:
         string = string.strip()
         try:
+            # convert string to ipaddress object
             address_obj = ipaddress.ip_address(string)
+            # check if ip is public
             if address_obj.is_global:
+                # remove duplicates
                 if address_obj not in seen:
-                    valid_ips.append(str(address_obj))
+                    valid_ips.append(address_obj)
                     seen.add(address_obj)
                 elif verbose:
                     print(f"Removed duplicate IP: {string}")
+            # if ip not public
             else:
                 if verbose:
                     print(f"Removed non-public IP: {string}")

--- a/src/ip_info/apis/abstractapicom.py
+++ b/src/ip_info/apis/abstractapicom.py
@@ -1,7 +1,8 @@
-from datetime import datetime
+import ipaddress
 import requests
 import sqlite3
-from typing import Dict, List
+from datetime import datetime
+from typing import Dict
 
 from ip_info.config import LOCAL_TIMEZONE
 from ip_info.db._add_to_db import _insert_ip_info, _insert_query_info
@@ -12,8 +13,8 @@ def abstractapicom(
     *,
     api_name: str,
     api_display_name: str,
-    ip_addresses: List,
-    rate_limits: List[Dict],
+    ip_addresses: list[ipaddress.IPv4Address | ipaddress.IPv6Address],
+    rate_limits: list[Dict],
     api_key: str,
     db_conn: sqlite3.Connection
 ) -> None:
@@ -31,13 +32,11 @@ def abstractapicom(
             print("Rate limit reached. Skipping query.")
             continue
 
-        # build request params
         params = {
             "api_key": api_key,
-            "ip_address": ip_address
+            "ip_address": str(ip_address)
         }
 
-        # make request
         try:
             print(f"Querying {api_display_name} for {ip_address}")
             response = requests.get(url, params=params)
@@ -94,7 +93,7 @@ def abstractapicom(
 
         entry = {
             "timestamp": last_request_time,
-            "ip_address": ip_address,
+            "ip_address": str(ip_address),
             "api_name": api_name,
             "api_display_name": api_display_name,
             "risk": "",

--- a/src/ip_info/apis/ipapico.py
+++ b/src/ip_info/apis/ipapico.py
@@ -1,7 +1,8 @@
-from datetime import datetime
+import ipaddress
 import requests
 import sqlite3
-from typing import Dict, List
+from datetime import datetime
+from typing import Dict
 
 from ip_info.config import LOCAL_TIMEZONE
 from ip_info.db._add_to_db import _insert_ip_info, _insert_query_info
@@ -12,13 +13,13 @@ def ipapico(
     *,
     api_name: str,
     api_display_name: str,
-    ip_addresses: List,
-    rate_limits: List[Dict],
+    ip_addresses: list[ipaddress.IPv4Address | ipaddress.IPv6Address],
+    rate_limits: list[Dict],
     api_key: str, # no key required
     db_conn: sqlite3.Connection
-):
+) -> None:
+    
     base_url = "https://ipapi.co"
-    last_request_time = None
 
     for ip_address in ip_addresses:
 
@@ -55,7 +56,7 @@ def ipapico(
 
         entry = {
             "timestamp": last_request_time,
-            "ip_address": ip_address,
+            "ip_address": str(ip_address),
             "api_name": api_name,
             "api_display_name": api_display_name,
             "risk": "",

--- a/src/ip_info/apis/ipapicom.py
+++ b/src/ip_info/apis/ipapicom.py
@@ -1,7 +1,8 @@
-from datetime import datetime
+import ipaddress
 import requests
 import sqlite3
-from typing import Dict, List
+from datetime import datetime
+from typing import Dict
 
 from ip_info.config import LOCAL_TIMEZONE
 from ip_info.db._add_to_db import _insert_ip_info, _insert_query_info
@@ -12,11 +13,11 @@ def ipapicom(
     *,
     api_name: str,
     api_display_name: str,
-    ip_addresses: List,
-    rate_limits: List[Dict],
+    ip_addresses: list[ipaddress.IPv4Address | ipaddress.IPv6Address],
+    rate_limits: list[Dict],
     api_key: str,
     db_conn: sqlite3.Connection
-):
+) -> None:
     
     base_url = "https://api.ipapi.com/api"
 
@@ -65,7 +66,7 @@ def ipapicom(
 
         entry = {
             "timestamp": last_request_time,
-            "ip_address": ip_address,
+            "ip_address": str(ip_address),
             "api_name": api_name,
             "api_display_name": api_display_name,
             "risk": "",

--- a/src/ip_info/apis/ipgeolocationio.py
+++ b/src/ip_info/apis/ipgeolocationio.py
@@ -1,7 +1,8 @@
-from datetime import datetime
+import ipaddress
 import requests
 import sqlite3
-from typing import Dict, List
+from datetime import datetime
+from typing import Dict
 
 from ip_info.config import LOCAL_TIMEZONE
 from ip_info.db._add_to_db import _insert_ip_info, _insert_query_info
@@ -12,11 +13,11 @@ def ipgeolocationio(
     *,
     api_name: str,
     api_display_name: str,
-    ip_addresses: List,
-    rate_limits: List[Dict],
+    ip_addresses: list[ipaddress.IPv4Address | ipaddress.IPv6Address],
+    rate_limits: list[Dict],
     api_key: str,
     db_conn: sqlite3.Connection
-):
+) -> None:
     
     url = "https://api.ipgeolocation.io/v2/ipgeo"
 
@@ -32,7 +33,7 @@ def ipgeolocationio(
             continue
 
         # build request params
-        params = {"apiKey": api_key, "ip": ip_address}
+        params = {"apiKey": api_key, "ip": str(ip_address)}
 
         # make request
         try:
@@ -56,7 +57,7 @@ def ipgeolocationio(
 
         entry = {
             "timestamp": last_request_time,
-            "ip_address": ip_address,
+            "ip_address": str(ip_address),
             "api_name": api_name,
             "api_display_name": api_display_name,
             "risk": "",

--- a/src/ip_info/apis/virustotalcom.py
+++ b/src/ip_info/apis/virustotalcom.py
@@ -1,7 +1,8 @@
-from datetime import datetime
+import ipaddress
 import requests
 import sqlite3
-from typing import Dict, List
+from datetime import datetime
+from typing import Dict
 
 from ip_info.config import LOCAL_TIMEZONE
 from ip_info.db._add_to_db import _insert_ip_info, _insert_query_info
@@ -12,11 +13,11 @@ def virustotalcom(
     *,
     api_name: str,
     api_display_name: str,
-    ip_addresses: List,
-    rate_limits: List[Dict],
+    ip_addresses: list[ipaddress.IPv4Address | ipaddress.IPv6Address],
+    rate_limits: list[Dict],
     api_key: str,
     db_conn: sqlite3.Connection
-):
+) -> None:
     
     base_url = "https://www.virustotal.com/api/v3/ip_addresses"
 
@@ -32,7 +33,7 @@ def virustotalcom(
             continue
 
         # build request params
-        url = f"{base_url}/{ip_address}"
+        url = f"{base_url}/{str(ip_address)}"
         headers = {"x-apikey": api_key}
 
         try:
@@ -74,7 +75,7 @@ def virustotalcom(
 
         entry = {
             "timestamp": last_request_time,
-            "ip_address": ip_address,
+            "ip_address": str(ip_address),
             "api_name": api_name,
             "api_display_name": api_display_name,
             "risk": malicious,

--- a/src/ip_info/keys.py
+++ b/src/ip_info/keys.py
@@ -1,5 +1,6 @@
 import getpass
 import keyring
+from typing import List
 
 from ip_info.config import API_METADATA
 
@@ -7,11 +8,9 @@ _KEYRING_SERVICE = "ip_info"
 
 
 def _get_api_key(api_name: str) -> str | None:
-    """Return stored key for *api_id* (or None if unset)."""
     return keyring.get_password(_KEYRING_SERVICE, api_name)
 
 def _set_api_key(api_name: str, api_key: str) -> None:
-    """Save / overwrite *api_key* for *api_id*."""
     keyring.set_password(_KEYRING_SERVICE, api_name, api_key)
 
 
@@ -20,17 +19,13 @@ def ip_info_keys() -> None:
     Interactive terminal menu for viewing or updating API keys.
     """
 
-    api_ids = [
-        api_id
-        for api_id, meta in API_METADATA.items()
-        if meta.get("requires_key", False)
-    ]
+    api_names: List[str] = list(API_METADATA.keys())
 
     while True:
         print("\n=== API KEY MANAGER ===")
-        for idx, api_id in enumerate(api_ids, 1):
-            name = API_METADATA[api_id]["api_display_name"]
-            print(f"{idx}. {name}")
+        for index, api_name in enumerate(api_names, 1):
+            name = API_METADATA[api_name]["api_display_name"]
+            print(f"{index}. {name}")
         print("q. Quit")
 
         sel = input("Select an API: ").strip().lower()
@@ -39,13 +34,13 @@ def ip_info_keys() -> None:
             break
 
         try:
-            api_idx = int(sel) - 1
-            api_id = api_ids[api_idx]
+            api_index = int(sel) - 1
+            api_name = api_names[api_index]
         except (ValueError, IndexError):
             print("⚠️  Invalid choice.")
             continue
 
-        display_name = API_METADATA[api_id]["api_display_name"]
+        display_name = API_METADATA[api_name]["api_display_name"]
         while True:
             print(f"\n--- {display_name} ---")
             print("1. Show stored key")
@@ -54,19 +49,19 @@ def ip_info_keys() -> None:
 
             action = input("Choose an option: ").strip().lower()
             if action == "1":
-                key = _get_api_key(api_id)
+                key = _get_api_key(api_name)
                 print(f"Current key: {key or 'No key stored.'}")
             elif action == "2":
                 new_key = getpass.getpass("Enter new key (input hidden): ").strip()
                 if new_key:
-                    _set_api_key(api_id, new_key)
-                    print("✓ Key saved.")
+                    _set_api_key(api_name, new_key)
+                    print("✅ Key saved.")
                 else:
                     print("⚠️  Empty key - nothing saved.")
             elif action in {"b", "back"}:
                 break
             else:
-                print("⚠️  Invalid option.")
+              print("⚠️  Invalid choice.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Found criminalip.io doesn't accept ipv6 addresses Updated so ipaddress objects are passed through to api function, rather than strings. Added filter so criminalipio doesn't process ipv6 addresses.