### PR TITLE
fix(rate-limit): wait instead of dropping queries

### DIFF
--- a/src/ip_info/apis/abstractapicom.py
+++ b/src/ip_info/apis/abstractapicom.py
@@ -9,7 +9,7 @@ import requests
 
 from ip_info.config import LOCAL_TIMEZONE, REQUEST_TIMEOUT
 from ip_info.db._add_to_db import _insert_ip_info, _insert_query_info
-from ip_info.db._query_db import _check_rate_limits, _is_db_entry_recent
+from ip_info.db._query_db import _is_db_entry_recent, _respect_rate_limit
 
 
 def abstractapicom(
@@ -29,9 +29,8 @@ def abstractapicom(
         if _is_db_entry_recent(api_name, ip_address, db_conn):
             continue
 
-        # check rate limits
-        if _check_rate_limits(api_name, rate_limits, db_conn):
-            print("Rate limit reached. Skipping query.")
+        # wait until the rate limit clears, or skip if the wait is too long
+        if _respect_rate_limit(api_name, api_display_name, rate_limits, db_conn):
             continue
 
         params = {"api_key": api_key, "ip_address": str(ip_address)}

--- a/src/ip_info/apis/abuseipdbcom.py
+++ b/src/ip_info/apis/abuseipdbcom.py
@@ -9,7 +9,7 @@ import requests
 
 from ip_info.config import LOCAL_TIMEZONE, REQUEST_TIMEOUT
 from ip_info.db._add_to_db import _insert_ip_info, _insert_query_info
-from ip_info.db._query_db import _check_rate_limits, _is_db_entry_recent
+from ip_info.db._query_db import _is_db_entry_recent, _respect_rate_limit
 
 
 def abuseipdbcom(
@@ -30,9 +30,8 @@ def abuseipdbcom(
         if _is_db_entry_recent(api_name, ip_address, db_conn):
             continue
 
-        # check rate limits
-        if _check_rate_limits(api_name, rate_limits, db_conn):
-            print("Rate limit reached. Skipping query.")
+        # wait until the rate limit clears, or skip if the wait is too long
+        if _respect_rate_limit(api_name, api_display_name, rate_limits, db_conn):
             continue
 
         params = {"ipAddress": str(ip_address), "maxAgeInDays": "365"}

--- a/src/ip_info/apis/criminalipio.py
+++ b/src/ip_info/apis/criminalipio.py
@@ -9,7 +9,7 @@ import requests
 
 from ip_info.config import LOCAL_TIMEZONE, REQUEST_TIMEOUT
 from ip_info.db._add_to_db import _insert_ip_info, _insert_query_info
-from ip_info.db._query_db import _check_rate_limits, _is_db_entry_recent
+from ip_info.db._query_db import _is_db_entry_recent, _respect_rate_limit
 
 
 def criminalipio(
@@ -33,9 +33,8 @@ def criminalipio(
         if _is_db_entry_recent(api_name, ip_address, db_conn):
             continue
 
-        # check rate limits
-        if _check_rate_limits(api_name, rate_limits, db_conn):
-            print("Rate limit reached. Skipping query.")
+        # wait until the rate limit clears, or skip if the wait is too long
+        if _respect_rate_limit(api_name, api_display_name, rate_limits, db_conn):
             continue
 
         params = {"ip": str(ip_address)}

--- a/src/ip_info/apis/ip2locationio.py
+++ b/src/ip_info/apis/ip2locationio.py
@@ -9,7 +9,7 @@ import requests
 
 from ip_info.config import LOCAL_TIMEZONE, REQUEST_TIMEOUT
 from ip_info.db._add_to_db import _insert_ip_info, _insert_query_info
-from ip_info.db._query_db import _check_rate_limits, _is_db_entry_recent
+from ip_info.db._query_db import _is_db_entry_recent, _respect_rate_limit
 
 
 def ip2locationio(
@@ -42,8 +42,7 @@ def ip2locationio(
                     "error_text": "Invalid API key or insufficient query.",
                 },
             ]
-        if _check_rate_limits(api_name, rate_limits, db_conn):
-            print("Rate limit reached. Skipping query.")
+        if _respect_rate_limit(api_name, api_display_name, rate_limits, db_conn):
             continue
 
         params = {

--- a/src/ip_info/apis/ipapico.py
+++ b/src/ip_info/apis/ipapico.py
@@ -9,7 +9,7 @@ import requests
 
 from ip_info.config import LOCAL_TIMEZONE, REQUEST_TIMEOUT
 from ip_info.db._add_to_db import _insert_ip_info, _insert_query_info
-from ip_info.db._query_db import _check_rate_limits, _is_db_entry_recent
+from ip_info.db._query_db import _is_db_entry_recent, _respect_rate_limit
 
 
 def ipapico(
@@ -29,9 +29,8 @@ def ipapico(
         if _is_db_entry_recent(api_name, ip_address, db_conn):
             continue
 
-        # check rate limits
-        if _check_rate_limits(api_name, rate_limits, db_conn):
-            print("Rate limit reached. Skipping query.")
+        # wait until the rate limit clears, or skip if the wait is too long
+        if _respect_rate_limit(api_name, api_display_name, rate_limits, db_conn):
             continue
 
         url = f"{base_url}/{ip_address}/json/"

--- a/src/ip_info/apis/ipapicom.py
+++ b/src/ip_info/apis/ipapicom.py
@@ -9,7 +9,7 @@ import requests
 
 from ip_info.config import LOCAL_TIMEZONE, REQUEST_TIMEOUT
 from ip_info.db._add_to_db import _insert_ip_info, _insert_query_info
-from ip_info.db._query_db import _check_rate_limits, _is_db_entry_recent
+from ip_info.db._query_db import _is_db_entry_recent, _respect_rate_limit
 
 
 def ipapicom(
@@ -31,9 +31,8 @@ def ipapicom(
         if recent_entry:
             continue
 
-        # check rate limits
-        if _check_rate_limits(api_name, rate_limits, db_conn):
-            print("Rate limit reached. Skipping query.")
+        # wait until the rate limit clears, or skip if the wait is too long
+        if _respect_rate_limit(api_name, api_display_name, rate_limits, db_conn):
             continue
 
         # build request params

--- a/src/ip_info/apis/ipapiis.py
+++ b/src/ip_info/apis/ipapiis.py
@@ -10,7 +10,7 @@ import requests
 
 from ip_info.config import LOCAL_TIMEZONE, REQUEST_TIMEOUT
 from ip_info.db._add_to_db import _insert_ip_info, _insert_query_info
-from ip_info.db._query_db import _check_rate_limits, _is_db_entry_recent
+from ip_info.db._query_db import _is_db_entry_recent, _respect_rate_limit
 
 
 def ipapiis(
@@ -37,9 +37,8 @@ def ipapiis(
 
     # split ips into chunks for bulk query
     for i in range(0, len(ips_to_query), max_chunk_size):
-        # check rate limits
-        if _check_rate_limits(api_name, rate_limits, db_conn):
-            print("Rate limit reached. Skipping query.")
+        # wait until the rate limit clears, or skip if the wait is too long
+        if _respect_rate_limit(api_name, api_display_name, rate_limits, db_conn):
             continue
 
         # build request params

--- a/src/ip_info/apis/ipapiorg.py
+++ b/src/ip_info/apis/ipapiorg.py
@@ -9,7 +9,7 @@ import requests
 
 from ip_info.config import LOCAL_TIMEZONE, REQUEST_TIMEOUT
 from ip_info.db._add_to_db import _insert_ip_info, _insert_query_info
-from ip_info.db._query_db import _check_rate_limits, _is_db_entry_recent
+from ip_info.db._query_db import _is_db_entry_recent, _respect_rate_limit
 
 
 def ipapiorg(
@@ -32,9 +32,8 @@ def ipapiorg(
 
     # split ips into chunks
     for i in range(0, len(ips_to_query), max_chunk_size):
-        # check rate limits
-        if _check_rate_limits(api_name, rate_limits, db_conn):
-            print("Rate limit reached. Skipping query.")
+        # wait until the rate limit clears, or skip if the wait is too long
+        if _respect_rate_limit(api_name, api_display_name, rate_limits, db_conn):
             continue
 
         # build request params

--- a/src/ip_info/apis/ipdashapicom.py
+++ b/src/ip_info/apis/ipdashapicom.py
@@ -9,7 +9,7 @@ import requests
 
 from ip_info.config import LOCAL_TIMEZONE, REQUEST_TIMEOUT
 from ip_info.db._add_to_db import _insert_ip_info, _insert_query_info
-from ip_info.db._query_db import _check_rate_limits, _is_db_entry_recent
+from ip_info.db._query_db import _is_db_entry_recent, _respect_rate_limit
 
 
 def ipdashapicom(
@@ -33,9 +33,8 @@ def ipdashapicom(
 
     # split ips into chunks for bulk query
     for i in range(0, len(ips_to_query), max_chunk_size):
-        # check rate limits
-        if _check_rate_limits(api_name, rate_limits, db_conn):
-            print("Rate limit reached. Skipping query.")
+        # wait until the rate limit clears, or skip if the wait is too long
+        if _respect_rate_limit(api_name, api_display_name, rate_limits, db_conn):
             continue
 
         # build request params

--- a/src/ip_info/apis/ipgeolocationio.py
+++ b/src/ip_info/apis/ipgeolocationio.py
@@ -9,7 +9,7 @@ import requests
 
 from ip_info.config import LOCAL_TIMEZONE, REQUEST_TIMEOUT
 from ip_info.db._add_to_db import _insert_ip_info, _insert_query_info
-from ip_info.db._query_db import _check_rate_limits, _is_db_entry_recent
+from ip_info.db._query_db import _is_db_entry_recent, _respect_rate_limit
 
 
 def ipgeolocationio(
@@ -29,9 +29,8 @@ def ipgeolocationio(
         if _is_db_entry_recent(api_name, ip_address, db_conn):
             continue
 
-        # check rate limits
-        if _check_rate_limits(api_name, rate_limits, db_conn):
-            print("Rate limit reached. Skipping query.")
+        # wait until the rate limit clears, or skip if the wait is too long
+        if _respect_rate_limit(api_name, api_display_name, rate_limits, db_conn):
             continue
 
         # build request params

--- a/src/ip_info/apis/ipqueryio.py
+++ b/src/ip_info/apis/ipqueryio.py
@@ -9,7 +9,7 @@ import requests
 
 from ip_info.config import LOCAL_TIMEZONE, REQUEST_TIMEOUT
 from ip_info.db._add_to_db import _insert_ip_info, _insert_query_info
-from ip_info.db._query_db import _check_rate_limits, _is_db_entry_recent
+from ip_info.db._query_db import _is_db_entry_recent, _respect_rate_limit
 
 
 def ipqueryio(
@@ -31,9 +31,8 @@ def ipqueryio(
         return
 
     for i in range(0, len(ips_to_query), max_chunk_size):
-        # check rate limits
-        if _check_rate_limits(api_name, rate_limits, db_conn):
-            print("Rate limit reached. Skipping query.")
+        # wait until the rate limit clears, or skip if the wait is too long
+        if _respect_rate_limit(api_name, api_display_name, rate_limits, db_conn):
             continue
 
         # build request params

--- a/src/ip_info/apis/ipregistryco.py
+++ b/src/ip_info/apis/ipregistryco.py
@@ -9,7 +9,7 @@ import requests
 
 from ip_info.config import LOCAL_TIMEZONE, REQUEST_TIMEOUT
 from ip_info.db._add_to_db import _insert_ip_info, _insert_query_info
-from ip_info.db._query_db import _check_rate_limits, _is_db_entry_recent
+from ip_info.db._query_db import _is_db_entry_recent, _respect_rate_limit
 
 
 def ipregistryco(
@@ -31,9 +31,8 @@ def ipregistryco(
         return
 
     for i in range(0, len(ips_to_query), max_chunk_size):
-        # check rate limits
-        if _check_rate_limits(api_name, rate_limits, db_conn):
-            print("Rate limit reached. Skipping query.")
+        # wait until the rate limit clears, or skip if the wait is too long
+        if _respect_rate_limit(api_name, api_display_name, rate_limits, db_conn):
             continue
 
         # build request params

--- a/src/ip_info/apis/virustotalcom.py
+++ b/src/ip_info/apis/virustotalcom.py
@@ -9,7 +9,7 @@ import requests
 
 from ip_info.config import LOCAL_TIMEZONE, REQUEST_TIMEOUT
 from ip_info.db._add_to_db import _insert_ip_info, _insert_query_info
-from ip_info.db._query_db import _check_rate_limits, _is_db_entry_recent
+from ip_info.db._query_db import _is_db_entry_recent, _respect_rate_limit
 
 
 def virustotalcom(
@@ -29,9 +29,8 @@ def virustotalcom(
         if _is_db_entry_recent(api_name, ip_address, db_conn):
             continue
 
-        # check rate limits
-        if _check_rate_limits(api_name, rate_limits, db_conn):
-            print("Rate limit reached. Skipping query.")
+        # wait until the rate limit clears, or skip if the wait is too long
+        if _respect_rate_limit(api_name, api_display_name, rate_limits, db_conn):
             continue
 
         # build request params

--- a/src/ip_info/config.py
+++ b/src/ip_info/config.py
@@ -228,6 +228,7 @@ TIMEZONE_STRING = "America/New_York"
 LOCAL_TIMEZONE = ZoneInfo(TIMEZONE_STRING)
 MAX_AGE = 90
 REQUEST_TIMEOUT = 10  # seconds; timeout for outbound provider HTTP requests
+MAX_RATE_LIMIT_WAIT = 1  # seconds; longest we block-wait on a rate limit before skipping
 
 BASE_DIR: Final[str] = os.path.dirname(os.path.abspath(__file__))
 DB_PATH: Final[str] = os.path.join(BASE_DIR, "ip_info.db")

--- a/src/ip_info/db/_query_db.py
+++ b/src/ip_info/db/_query_db.py
@@ -5,13 +5,71 @@ import time
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
-from ip_info.config import IP_TABLE_NAME, LOCAL_TIMEZONE, MAX_AGE, QUERY_TABLE_NAME
+from ip_info.config import (
+    IP_TABLE_NAME,
+    LOCAL_TIMEZONE,
+    MAX_AGE,
+    MAX_RATE_LIMIT_WAIT,
+    QUERY_TABLE_NAME,
+)
+
+
+def _rolling_window(timeframe: str) -> timedelta:
+    """Return the rolling-window length for a rate-limit timeframe."""
+    windows = {
+        "second": timedelta(seconds=1),
+        "minute": timedelta(minutes=1),
+        "hour": timedelta(hours=1),
+        "day": timedelta(days=1),
+        "month": timedelta(days=30),
+    }
+    try:
+        return windows[timeframe]
+    except KeyError:
+        raise ValueError(f"Unknown timeframe: {timeframe!r}") from None
+
+
+def _absolute_window(now: datetime, timeframe: str) -> tuple[datetime, datetime]:
+    """Return the [start, end) bounds of the absolute window containing now."""
+    if timeframe == "second":
+        start = now.replace(microsecond=0)
+        end = start + timedelta(seconds=1)
+    elif timeframe == "minute":
+        start = now.replace(second=0, microsecond=0)
+        end = start + timedelta(minutes=1)
+    elif timeframe == "hour":
+        start = now.replace(minute=0, second=0, microsecond=0)
+        end = start + timedelta(hours=1)
+    elif timeframe == "day":
+        start = now.replace(hour=0, minute=0, second=0, microsecond=0)
+        end = start + timedelta(days=1)
+    elif timeframe == "month":
+        start = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+        if now.month == 12:
+            end = start.replace(year=now.year + 1, month=1)
+        else:
+            end = start.replace(month=now.month + 1)
+    else:
+        raise ValueError(f"Unknown timeframe: {timeframe!r}")
+    return start, end
+
+
+def _matching_error_rows(
+    rows: list[dict[str, Any]], status_code: int | None, error_text: str | None
+) -> list[dict[str, Any]]:
+    """Return rows whose response signals that the provider's rate limit was hit."""
+    if status_code is None:
+        return []
+    matching = [row for row in rows if row["status_code"] == status_code]
+    if error_text:
+        matching = [row for row in matching if error_text in (row["error_text"] or "")]
+    return matching
 
 
 def _check_rate_limits(
     api_name: str, rate_limits: list[dict[str, Any]], db_conn: sqlite3.Connection
-) -> bool:
-    """Enforce rate_limits for api_name, supporting 'rolling' or 'absolute' windows.
+) -> datetime:
+    """Compute the earliest time a query for api_name satisfies every rate limit.
 
     Accepts rate_limits dict. Should have one entry for each type of rate limit the
     provider has. (per second, per hour, daily, monthly, etc...)
@@ -24,8 +82,8 @@ def _check_rate_limits(
     11:59pm.
 
     status_code,error_text - If a query returns this status code(and error_text if
-    present), it means the rate limit has been reached. No further queries for the given
-    time period.
+    present), it means the rate limit has been reached. No further queries until that
+    response leaves the window.
 
     rate_limits = [
         {
@@ -43,9 +101,14 @@ def _check_rate_limits(
         },
     ]
 
+    A limit is considered reached when the window already holds query_limit calls
+    (at most query_limit calls per window). This function never sleeps; waiting is
+    the caller's responsibility (see _respect_rate_limit).
+
     Returns:
-      True - Rate limit reached. Do not query.
-      False - No rate limit reached. Proceed with query.
+      A timezone-aware datetime in LOCAL_TIMEZONE. A value at or before the current
+      time means the query may proceed immediately; a future value is the earliest
+      instant at which every configured limit is satisfied.
     """
     if db_conn is None:
         sys.exit("ERROR: no database connection provided.")
@@ -69,6 +132,7 @@ def _check_rate_limits(
     rows = cursor.fetchall()
 
     now = datetime.now(LOCAL_TIMEZONE)
+    free_times: list[datetime] = [now]
 
     for rate_limit in rate_limits:
         query_limit = rate_limit["query_limit"]
@@ -76,93 +140,64 @@ def _check_rate_limits(
         mode = rate_limit.get("type", "rolling")
         status_code = rate_limit.get("status_code")
         error_text = rate_limit.get("error_text")
-        limit_text = f"{query_limit}/{timeframe}"
 
-        # build window starting from current time
         if mode == "rolling":
-            if timeframe == "second":
-                window = timedelta(seconds=1)
-            elif timeframe == "minute":
-                window = timedelta(minutes=1)
-            elif timeframe == "hour":
-                window = timedelta(hours=1)
-            elif timeframe == "day":
-                window = timedelta(days=1)
-            elif timeframe == "month":
-                window = timedelta(days=30)
-            else:
-                raise ValueError(f"Unknown timeframe: {timeframe!r}")
-
+            window = _rolling_window(timeframe)
             cutoff = now - window
             timeframe_rows = [row for row in rows if row["timestamp"] >= cutoff]
 
-        # build window from start to end of current second/minute/day/etc...
-        elif mode == "absolute":
-            if timeframe == "second":
-                start = now.replace(microsecond=0)
-                end = start + timedelta(seconds=1)
-            elif timeframe == "minute":
-                start = now.replace(second=0, microsecond=0)
-                end = start + timedelta(minutes=1)
-            elif timeframe == "hour":
-                start = now.replace(minute=0, second=0, microsecond=0)
-                end = start + timedelta(hours=1)
-            elif timeframe == "day":
-                start = now.replace(hour=0, minute=0, second=0, microsecond=0)
-                end = start + timedelta(days=1)
-            elif timeframe == "month":
-                start = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
-                if now.month == 12:
-                    end = start.replace(year=now.year + 1, month=1)
-                else:
-                    end = start.replace(month=now.month + 1)
-            else:
-                raise ValueError(f"Unknown timeframe: {timeframe!r}")
+            if len(timeframe_rows) >= query_limit:
+                # free when enough of the oldest in-window calls age out that the
+                # window holds query_limit - 1 of them
+                timestamps = sorted(row["timestamp"] for row in timeframe_rows)
+                free_times.append(timestamps[len(timestamps) - query_limit] + window)
 
-            timeframe_rows = [row for row in rows if start <= row["timestamp"] < end]  # FIXME
+            error_rows = _matching_error_rows(timeframe_rows, status_code, error_text)
+            if error_rows:
+                # blocked until the newest rate-limit response leaves the window
+                free_times.append(max(row["timestamp"] for row in error_rows) + window)
+
+        elif mode == "absolute":
+            start, end = _absolute_window(now, timeframe)
+            timeframe_rows = [row for row in rows if start <= row["timestamp"] < end]
+
+            if len(timeframe_rows) >= query_limit:
+                free_times.append(end)
+
+            if _matching_error_rows(timeframe_rows, status_code, error_text):
+                free_times.append(end)
 
         else:
             raise ValueError(f"type must be 'rolling' or 'absolute', got {mode!r}")
 
-        # if query limit exceeded
-        if len(timeframe_rows) >= query_limit:
-            # if seconds, wait until next second and return true
-            if timeframe == "second":
-                # compute sleep duration
-                if mode == "rolling":
-                    earliest_ts = min(row["timestamp"] for row in timeframe_rows)
-                    wake_at = earliest_ts + timedelta(seconds=1)
-                else:  # absolute: wake at next boundary
-                    wake_at = end
-                wait = (wake_at - now).total_seconds()
-                if wait > 0:
-                    time.sleep(wait)
-                query_check = True
-            # if anything other than seconds, return false
-            else:
-                print(f"{api_name} limit hit: {limit_text}")
-                query_check = False
-        # if query limit not exceeded, return true
-        else:
-            query_check = True
+    return max(free_times)
 
-        # check if error message found
-        status_code_rows = [row for row in timeframe_rows if row["status_code"] == status_code]
-        if status_code_rows:
-            if error_text:
-                error_check = any(error_text in row["error_text"] for row in status_code_rows)
-                error_check = not error_check
-            else:
-                error_check = False
-        # return true if no queries match
-        else:
-            error_check = True
 
-        # return False (allow query) only when both tests pass; otherwise True (block query)
-        return not (query_check and error_check)
+def _respect_rate_limit(
+    api_name: str,
+    api_display_name: str,
+    rate_limits: list[dict[str, Any]],
+    db_conn: sqlite3.Connection,
+) -> bool:
+    """Wait until the next allowed query time, or report that the query should be skipped.
 
-    # if no rate limits passed, allow query
-    return False
+    Sleeps until _check_rate_limits allows a query, as long as the wait is at most
+    MAX_RATE_LIMIT_WAIT seconds.
+
+    Returns:
+      True - Next allowed time is too far away. Skip the query.
+      False - Clear to query now (after sleeping, if a short wait was needed).
+    """
+    allowed_at = _check_rate_limits(api_name, rate_limits, db_conn)
+    wait = (allowed_at - datetime.now(LOCAL_TIMEZONE)).total_seconds()
+    if wait <= 0:
+        return False
+    if wait <= MAX_RATE_LIMIT_WAIT:
+        print(f"Rate limit reached for {api_display_name}. Waiting {wait:.1f}s...")
+        time.sleep(wait)
+        return False
+    print(f"Rate limit reached for {api_display_name}. Next slot in {wait:.0f}s; skipping.")
+    return True
 
 
 def _fetch_ip_info(

--- a/tests/test_check_rate_limits.py
+++ b/tests/test_check_rate_limits.py
@@ -1,32 +1,314 @@
+"""Tests for the rate-limit datetime contract and the wait-or-skip helper."""
+
 import sqlite3
+import time
 from datetime import datetime, timedelta
 
-from ip_info.config import LOCAL_TIMEZONE
-from ip_info.db._query_db import _check_rate_limits
+import pytest
+
+from ip_info.config import LOCAL_TIMEZONE, MAX_RATE_LIMIT_WAIT
+from ip_info.db import _query_db
+from ip_info.db._query_db import (
+    _absolute_window,
+    _check_rate_limits,
+    _respect_rate_limit,
+    _rolling_window,
+)
+
+API = "demo"
 
 
-def _add_past_calls(
-    db_conn: sqlite3.Connection, api_name: str, seconds_ago: int, count: int
+def _ts(seconds_ago: float) -> datetime:
+    """Return a timezone-aware timestamp *seconds_ago* seconds in the past."""
+    return datetime.now(LOCAL_TIMEZONE) - timedelta(seconds=seconds_ago)
+
+
+def _insert_query(
+    db_conn: sqlite3.Connection,
+    timestamp: datetime,
+    status_code: int = 200,
+    error_text: str | None = "",
 ) -> None:
-    """Insert *count* fake query-log rows at *seconds_ago* into the past."""
-    then = datetime.now(LOCAL_TIMEZONE) - timedelta(seconds=seconds_ago)
+    """Insert one fake query-log row for the demo API at *timestamp*."""
     cur = db_conn.cursor()
-    for _ in range(count):
-        cur.execute(
-            "INSERT INTO api_queries (api_name,timestamp,status_code,error_text) VALUES (?,?,?,?)",
-            (api_name, then, 200, ""),
-        )
+    cur.execute(
+        "INSERT INTO api_queries (api_name,timestamp,status_code,error_text) VALUES (?,?,?,?)",
+        (API, timestamp, status_code, error_text),
+    )
     db_conn.commit()
 
 
-def test_second_rolling_limit(db_conn: sqlite3.Connection) -> None:
-    api = "demo"
+@pytest.mark.parametrize(
+    ("timeframe", "expected"),
+    [
+        ("second", timedelta(seconds=1)),
+        ("minute", timedelta(minutes=1)),
+        ("hour", timedelta(hours=1)),
+        ("day", timedelta(days=1)),
+        ("month", timedelta(days=30)),
+    ],
+)
+def test_rolling_window_lengths(timeframe: str, expected: timedelta) -> None:
+    """Each rolling timeframe maps to its window length."""
+    assert _rolling_window(timeframe) == expected
+
+
+def test_rolling_window_unknown_timeframe_raises() -> None:
+    """An unknown rolling timeframe fails loudly."""
+    with pytest.raises(ValueError, match="Unknown timeframe"):
+        _rolling_window("fortnight")
+
+
+@pytest.mark.parametrize(
+    ("timeframe", "expected_start", "expected_end"),
+    [
+        (
+            "second",
+            datetime(2026, 7, 6, 15, 30, 45, tzinfo=LOCAL_TIMEZONE),
+            datetime(2026, 7, 6, 15, 30, 46, tzinfo=LOCAL_TIMEZONE),
+        ),
+        (
+            "minute",
+            datetime(2026, 7, 6, 15, 30, tzinfo=LOCAL_TIMEZONE),
+            datetime(2026, 7, 6, 15, 31, tzinfo=LOCAL_TIMEZONE),
+        ),
+        (
+            "hour",
+            datetime(2026, 7, 6, 15, tzinfo=LOCAL_TIMEZONE),
+            datetime(2026, 7, 6, 16, tzinfo=LOCAL_TIMEZONE),
+        ),
+        (
+            "day",
+            datetime(2026, 7, 6, tzinfo=LOCAL_TIMEZONE),
+            datetime(2026, 7, 7, tzinfo=LOCAL_TIMEZONE),
+        ),
+        (
+            "month",
+            datetime(2026, 7, 1, tzinfo=LOCAL_TIMEZONE),
+            datetime(2026, 8, 1, tzinfo=LOCAL_TIMEZONE),
+        ),
+    ],
+)
+def test_absolute_window_bounds(
+    timeframe: str, expected_start: datetime, expected_end: datetime
+) -> None:
+    """Each absolute timeframe maps to the [start, end) bounds containing now."""
+    now = datetime(2026, 7, 6, 15, 30, 45, 123456, tzinfo=LOCAL_TIMEZONE)
+    assert _absolute_window(now, timeframe) == (expected_start, expected_end)
+
+
+def test_absolute_window_month_year_rollover() -> None:
+    """A December monthly window ends on January 1st of the next year."""
+    now = datetime(2026, 12, 15, 8, 0, tzinfo=LOCAL_TIMEZONE)
+    start, end = _absolute_window(now, "month")
+    assert start == datetime(2026, 12, 1, tzinfo=LOCAL_TIMEZONE)
+    assert end == datetime(2027, 1, 1, tzinfo=LOCAL_TIMEZONE)
+
+
+def test_absolute_window_unknown_timeframe_raises() -> None:
+    """An unknown absolute timeframe fails loudly."""
+    now = datetime(2026, 7, 6, tzinfo=LOCAL_TIMEZONE)
+    with pytest.raises(ValueError, match="Unknown timeframe"):
+        _absolute_window(now, "fortnight")
+
+
+def test_under_limit_allows_now(db_conn: sqlite3.Connection) -> None:
+    """Fewer in-window calls than the limit permits a query immediately."""
+    rate_limits = [{"query_limit": 3, "timeframe": "minute", "type": "rolling"}]
+    _insert_query(db_conn, _ts(10))
+    _insert_query(db_conn, _ts(5))
+
+    allowed_at = _check_rate_limits(API, rate_limits, db_conn)
+
+    assert allowed_at <= datetime.now(LOCAL_TIMEZONE)
+
+
+def test_no_rate_limits_allows_now(db_conn: sqlite3.Connection) -> None:
+    """An empty rate_limits list never blocks."""
+    _insert_query(db_conn, _ts(0))
+
+    allowed_at = _check_rate_limits(API, [], db_conn)
+
+    assert allowed_at <= datetime.now(LOCAL_TIMEZONE)
+
+
+def test_rolling_second_at_limit(db_conn: sqlite3.Connection) -> None:
+    """Hitting a rolling per-second limit frees up when the oldest call ages out."""
     rate_limits = [{"query_limit": 2, "timeframe": "second", "type": "rolling"}]
+    oldest = _ts(0)
+    _insert_query(db_conn, oldest)
+    _insert_query(db_conn, _ts(0))
 
-    # 2 queries in the last second → allowed after sleep handled by helper
-    _add_past_calls(db_conn, api, 0, 2)
-    assert _check_rate_limits(api, rate_limits, db_conn) is False  # should allow
+    allowed_at = _check_rate_limits(API, rate_limits, db_conn)
 
-    # 3 in window hits limit
-    _add_past_calls(db_conn, api, 0, 1)
-    assert _check_rate_limits(api, rate_limits, db_conn) is True  # should block
+    assert allowed_at == oldest + timedelta(seconds=1)
+
+
+def test_rolling_over_limit_by_more_than_one(db_conn: sqlite3.Connection) -> None:
+    """With count > limit, the wait ends when enough of the oldest calls age out."""
+    rate_limits = [{"query_limit": 2, "timeframe": "minute", "type": "rolling"}]
+    second_oldest = _ts(30)
+    _insert_query(db_conn, _ts(40))
+    _insert_query(db_conn, second_oldest)
+    _insert_query(db_conn, _ts(10))
+
+    allowed_at = _check_rate_limits(API, rate_limits, db_conn)
+
+    # timestamps[count - limit] = timestamps[1]; free once it leaves the window
+    assert allowed_at == second_oldest + timedelta(minutes=1)
+
+
+def test_absolute_over_limit_returns_window_end(db_conn: sqlite3.Connection) -> None:
+    """Hitting an absolute daily limit blocks until the next day boundary."""
+    rate_limits = [{"query_limit": 2, "timeframe": "day", "type": "absolute"}]
+    _insert_query(db_conn, _ts(1))
+    _insert_query(db_conn, _ts(0))
+
+    allowed_at = _check_rate_limits(API, rate_limits, db_conn)
+
+    now = datetime.now(LOCAL_TIMEZONE)
+    expected_end = now.replace(hour=0, minute=0, second=0, microsecond=0) + timedelta(days=1)
+    assert allowed_at == expected_end
+
+
+def test_provider_signalled_limit_blocks_until_window_clears(
+    db_conn: sqlite3.Connection,
+) -> None:
+    """A stored rate-limit response blocks until it leaves the rolling window."""
+    rate_limits = [
+        {
+            "query_limit": 100,
+            "timeframe": "minute",
+            "type": "rolling",
+            "status_code": 429,
+            "error_text": "Too many requests",
+        }
+    ]
+    limited_at = _ts(30)
+    _insert_query(db_conn, limited_at, status_code=429, error_text="Too many requests received")
+
+    allowed_at = _check_rate_limits(API, rate_limits, db_conn)
+
+    assert allowed_at == limited_at + timedelta(minutes=1)
+
+
+def test_provider_signalled_limit_absolute_blocks_until_window_end(
+    db_conn: sqlite3.Connection,
+) -> None:
+    """A stored rate-limit response in an absolute window blocks until its boundary."""
+    rate_limits = [
+        {
+            "query_limit": 1000,
+            "timeframe": "day",
+            "type": "absolute",
+            "status_code": 429,
+            "error_text": "Too many requests",
+        }
+    ]
+    _insert_query(db_conn, _ts(60), status_code=429, error_text="Too many requests")
+
+    allowed_at = _check_rate_limits(API, rate_limits, db_conn)
+
+    now = datetime.now(LOCAL_TIMEZONE)
+    expected_end = now.replace(hour=0, minute=0, second=0, microsecond=0) + timedelta(days=1)
+    assert allowed_at == expected_end
+
+
+def test_provider_signalled_error_text_mismatch_allows(db_conn: sqlite3.Connection) -> None:
+    """A matching status code with non-matching error text does not block."""
+    rate_limits = [
+        {
+            "query_limit": 100,
+            "timeframe": "minute",
+            "type": "rolling",
+            "status_code": 429,
+            "error_text": "Too many requests",
+        }
+    ]
+    _insert_query(db_conn, _ts(30), status_code=429, error_text="unrelated failure")
+    # a NULL error_text must not match (or crash) either
+    _insert_query(db_conn, _ts(20), status_code=429, error_text=None)
+
+    allowed_at = _check_rate_limits(API, rate_limits, db_conn)
+
+    assert allowed_at <= datetime.now(LOCAL_TIMEZONE)
+
+
+def test_multiple_limits_returns_latest_free_time(db_conn: sqlite3.Connection) -> None:
+    """With several limits hit, the result satisfies every limit (max of all)."""
+    rate_limits = [
+        {"query_limit": 1, "timeframe": "second", "type": "rolling"},
+        {"query_limit": 1, "timeframe": "day", "type": "absolute"},
+    ]
+    _insert_query(db_conn, _ts(0))
+
+    allowed_at = _check_rate_limits(API, rate_limits, db_conn)
+
+    now = datetime.now(LOCAL_TIMEZONE)
+    expected_end = now.replace(hour=0, minute=0, second=0, microsecond=0) + timedelta(days=1)
+    assert allowed_at == expected_end
+
+
+def test_unknown_timeframe_raises(db_conn: sqlite3.Connection) -> None:
+    """An unknown timeframe fails loudly."""
+    rate_limits = [{"query_limit": 1, "timeframe": "fortnight", "type": "rolling"}]
+
+    with pytest.raises(ValueError, match="Unknown timeframe"):
+        _check_rate_limits(API, rate_limits, db_conn)
+
+
+def test_unknown_mode_raises(db_conn: sqlite3.Connection) -> None:
+    """An unknown limit type fails loudly."""
+    rate_limits = [{"query_limit": 1, "timeframe": "day", "type": "sliding"}]
+
+    with pytest.raises(ValueError, match=r"rolling.*absolute"):
+        _check_rate_limits(API, rate_limits, db_conn)
+
+
+def test_respect_rate_limit_proceeds_immediately(
+    db_conn: sqlite3.Connection, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A next-allowed time in the past proceeds without sleeping."""
+    slept: list[float] = []
+    monkeypatch.setattr(time, "sleep", slept.append)
+    monkeypatch.setattr(
+        _query_db,
+        "_check_rate_limits",
+        lambda *args: datetime.now(LOCAL_TIMEZONE) - timedelta(seconds=10),
+    )
+
+    assert _respect_rate_limit(API, "Demo", [], db_conn) is False
+    assert slept == []
+
+
+def test_respect_rate_limit_waits_for_short_delays(
+    db_conn: sqlite3.Connection, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A wait within MAX_RATE_LIMIT_WAIT sleeps until the allowed time, then proceeds."""
+    slept: list[float] = []
+    monkeypatch.setattr(time, "sleep", slept.append)
+    monkeypatch.setattr(
+        _query_db,
+        "_check_rate_limits",
+        lambda *args: datetime.now(LOCAL_TIMEZONE) + timedelta(seconds=MAX_RATE_LIMIT_WAIT),
+    )
+
+    assert _respect_rate_limit(API, "Demo", [], db_conn) is False
+    assert len(slept) == 1
+    assert 0 < slept[0] <= MAX_RATE_LIMIT_WAIT
+
+
+def test_respect_rate_limit_skips_long_delays(
+    db_conn: sqlite3.Connection, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A wait beyond MAX_RATE_LIMIT_WAIT skips the query without sleeping."""
+    slept: list[float] = []
+    monkeypatch.setattr(time, "sleep", slept.append)
+    monkeypatch.setattr(
+        _query_db,
+        "_check_rate_limits",
+        lambda *args: datetime.now(LOCAL_TIMEZONE) + timedelta(seconds=MAX_RATE_LIMIT_WAIT + 60),
+    )
+
+    assert _respect_rate_limit(API, "Demo", [], db_conn) is True
+    assert slept == []


### PR DESCRIPTION
## Summary

The rate limiter used to be all-or-nothing: `_check_rate_limits` returned a
boolean, and the moment any configured limit was active the caller dropped the
lookup for that IP entirely. For providers with tight short-term limits — like
VirusTotal at 4 requests/minute — that meant losing results we could have had by
simply waiting a moment. The function also returned from inside its own loop, so
for providers with more than one limit entry only the *first* one was ever
checked.

This PR reworks the limiter around "wait a little, or skip if it's too long":

- `_check_rate_limits` is now a pure function that returns the earliest
  timezone-aware `datetime` at which a query satisfies *every* configured limit
  (rolling and absolute windows, plus provider-signalled 429/quota responses).
  It no longer sleeps, which makes it straightforward to unit-test without real
  delays. The per-window math moved into small helpers (`_rolling_window`,
  `_absolute_window`, `_matching_error_rows`).
- A new `_respect_rate_limit` helper holds the wait-or-skip policy in one place:
  if the next slot is within `MAX_RATE_LIMIT_WAIT` seconds it block-waits and
  proceeds, otherwise it prints how far off the slot is and skips. All 13 API
  modules now call this one-liner instead of their own three-line drop block.
- `MAX_RATE_LIMIT_WAIT` lives in `config.py` (currently **1 second**) so the
  threshold between "wait it out" and "skip for now" is a single, easy-to-tune
  constant.

One deliberate semantics change: a window that already holds exactly
`query_limit` calls is now treated as *limited* ("at most N per window"),
whereas the old code allowed one extra. The tests were rewritten for the new
contract, so this is the intended behavior going forward.

## Related Issues

<!-- No issue number encoded in the branch slug; add "Closes #N" if applicable. -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would change existing behavior)
- [ ] Documentation update
- [ ] Refactor / tooling (no functional change)

## How Has This Been Tested?

- `tests/test_check_rate_limits.py` was rewritten to cover the datetime
  contract and every branch of both helpers: under-limit, rolling per-second and
  over-by-more-than-one, absolute window boundaries (including the
  December→January month rollover), provider-signalled limits in both rolling
  and absolute modes, NULL `error_text` rows, and the three `_respect_rate_limit`
  outcomes (proceed / short wait / skip) with `time.sleep` monkeypatched so no
  test actually sleeps.
- `uv run pytest -m "not integration"` — 42 passed.
- `uv run ruff check .`, `uv run mypy`, and `uv run pre-commit run` — all clean.
- Manual smoke test against an in-memory DB confirmed the messaging: a
  just-consumed 1/second rolling limit printed a short "Waiting…" and proceeded
  after the wait, a hit daily limit printed "Next slot in …s; skipping" and
  skipped, and an empty limit list proceeded immediately.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my changes
- [x] I have commented my code where non-obvious
- [ ] I have updated documentation as needed
- [x] My changes generate no new warnings
- [x] New and existing tests pass locally
